### PR TITLE
docs: Update README to TestMu AI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
-# jest-environment-lambdatest
+# Run Jest Environment Tests on TestMu AI (Formerly LambdaTest)
 
-![Actions Status](https://github.com/LambdaTest/jest-environment-lambdatest/workflows/Actions%20Status/badge.svg?branch=master&event=push) [![npm version](http://img.shields.io/npm/v/jest-environment-lambdatest.svg?style=flat)](https://npmjs.org/package/jest-environment-lambdatest 'View this project on npm')
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://npmjs.org/package/jest-environment-lambdatest"><img src="https://img.shields.io/npm/v/jest-environment-lambdatest.svg?style=for-the-badge&labelColor=000" alt="npm version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
-Use Jest as test-runner for running your visual-tests and more using LambdaTest.
+## Getting Started
 
-## Usage
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-For using this environment, run first the following command in your terminal:
+With TestMu AI (Formerly LambdaTest), you can run Jest-based visual tests and Selenium automation tests across real browsers and operating systems. This package provides a Jest custom test environment that connects to the TestMu AI cloud grid, enabling you to use Jest as a test runner for cross-browser testing.
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (LTS version recommended).
+- [Jest](https://jestjs.io/) installed in your project.
+- A [TestMu AI account](https://www.testmuai.com/register/). Retrieve your **Username** and **Access Key** from the [TestMu AI Automation Dashboard](https://automation.testmuai.com/).
+
+### Setup
+
+Clone the repository:
+
+```bash
+git clone https://github.com/LambdaTest/jest-environment-lambdatest
+cd jest-environment-lambdatest
+```
+
+Install the package as a dev dependency:
 
 ```bash
 npm install --save-dev jest-environment-lambdatest
 ```
 
-Once it's done, configure your Jest config.
+Set your TestMu AI credentials as environment variables:
 
-### LambdaTest
+```bash
+export LT_USERNAME=YOUR_LAMBDATEST_USERNAME
+export LT_ACCESS_KEY=YOUR_LAMBDATEST_ACCESS_KEY
+```
 
-Assuming your configuration is defined in your `package.json`, add the following lines to your `globals` definition:
+Configure Jest in your `package.json`:
 
 ```json
 {
@@ -26,7 +53,7 @@ Assuming your configuration is defined in your `package.json`, add the following
     "globals": {
       "lambdatest": {
         "capabilities": {
-          "build": "jest and lambdatest with tunnel",
+          "build": "jest and lambdatest",
           "name": "jest demo",
           "platform": "Windows 10",
           "browserName": "Chrome",
@@ -38,39 +65,7 @@ Assuming your configuration is defined in your `package.json`, add the following
 }
 ```
 
-### LambdaTest Tunnel
-
-Assuming here also your configuration is defined in your `package.json`, add the following lines to your `globals` definition:
-
-```json
-{
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "lambdatest",
-    "globals": {
-      "lambdatest": {
-        "capabilities": {
-          "build": "jest and lambdatest with tunnel",
-          "name": "jest demo",
-          "platform": "Windows 10",
-          "browserName": "Chrome",
-          "version": "latest",
-          "tunnel": true
-        },
-        "tunnelOpts": {}
-      }
-    }
-  }
-}
-```
-
-### Loading the environment using annotation
-
-If you are running all your tests with JSDom as main environment, you can load the LambdaTest environment for a specific file by adding a Jest annotation at the beginning of your file.
-
-Here is an example:
-
-my-visual-test.spec.js:
+You can also load the environment per test file using the Jest annotation:
 
 ```javascript
 /**
@@ -82,7 +77,6 @@ describe('my visual test', () => {
   let driver;
 
   beforeAll(async () => {
-    // you can override the default configuration
     driver = await global.__driver__({
       build: 'jest and lambdatest',
       name: 'jest demo',
@@ -90,30 +84,23 @@ describe('my visual test', () => {
       browserName: 'Chrome',
       version: '80.0',
     });
-    driver.get('https://www.lambdatest.com');
-  }, 20000); // this timeout is required because starting a session in LambdaTest can take ages
+    driver.get('https://www.testmuai.com');
+  }, 20000);
 
   afterAll(async () => {
-    // can be omitted
     await driver.quit();
   });
 
   it('test title', async () => {
     const title = await driver.getTitle();
-    expect(title).toBe('Cross Browser Testing Tools | Free Automated Website Testing | LambdaTest');
+    expect(title).toBeTruthy();
   });
 });
 ```
 
-### Credentials
+### Run tests
 
-If you aren't willing to put your credentials in your `package.json` file, you can export in your environment `LT_USERNAME` and `LT_ACCESS_KEY`. If you do so, `userName` and `accessKey` can be omitted.
-
-## Examples
-
-In the `examples` folder, you can find an example using `react-create-app`.
-
-To run the test, type the following commands in your terminal:
+Run the example tests from the `examples` folder:
 
 ```bash
 cd examples/with-lambdatest-tunnel
@@ -121,29 +108,71 @@ yarn install
 yarn test
 ```
 
-The `test` script will run a basic e2e tests, a visual tests making a snapshot of the web-app and the unit-tests.
+### Local testing with TestMu AI Tunnel
 
-## Contribute
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-#### Reporting bugs
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-Our GitHub Issue Tracker will help you log bug reports.
+Enable the tunnel capability in your Jest configuration:
 
-Tips for submitting an issue:
-Keep in mind, you don't end up submitting two issues with the same information. Make sure you add a unique input in every issue that you submit. You could also provide a "+1" value in the comments.
+```json
+{
+  "jest": {
+    "testEnvironment": "lambdatest",
+    "globals": {
+      "lambdatest": {
+        "capabilities": {
+          "tunnel": true
+        },
+        "tunnelOpts": {}
+      }
+    }
+  }
+}
+```
 
-Always provide the steps to reproduce before you submit a bug.
-Provide the environment details where you received the issue i.e. Browser Name, Browser Version, Operating System, Screen Resolution and more.
-Describe the situation that led to your encounter with bug.
-Describe the expected output, and the actual output precisely.
+## Contributions
 
-#### Pull Requests
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Angular CLI version.
 
-We don't want to pull breaks in case you want to customize your LambdaTest experience. Before you proceed with implementing pull requests, keep in mind the following.
-Make sure you stick to coding conventions.
-Once you include tests, ensure that they all pass.
-Make sure to clean up your Git history, prior your submission of a pull-request. You can do so by using the interactive rebase command for committing and squashing, simultaneously with minor changes + fixes into the corresponding commits.
+## TestMu AI (Formerly LambdaTest) Community
 
-## About LambdaTest
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-[LambdaTest](https://www.lambdatest.com/) is a cloud based selenium grid infrastructure that can help you run automated cross browser compatibility tests on 2000+ different browser and operating system environments. LambdaTest supports all programming languages and frameworks that are supported with Selenium, and have easy integrations with all popular CI/CD platforms. It's a perfect solution to bring your [selenium automation testing](https://www.lambdatest.com/selenium-automation) to cloud based infrastructure that not only helps you increase your test coverage over multiple desktop and mobile browsers, but also allows you to cut down your test execution time by running tests on parallel.
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
+
+## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+Learn modern testing through tutorials, guides, videos, and weekly updates:
+
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
+
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
+
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+ð Find the new home for [LambdaTest](https://www.testmuai.com).
+
+### How LambdaTest Evolved into TestMu AI
+
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
+
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
+
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
Updates README to follow the standard TestMu AI (Formerly LambdaTest) template.